### PR TITLE
Fixes max_width parameter

### DIFF
--- a/libgif.js
+++ b/libgif.js
@@ -797,7 +797,7 @@ var SuperGif = function ( opts ) {
 
 	var get_canvas_scale = function() {
 		var scale;
-		if (options.max_width && hdr) {
+		if (options.max_width && hdr && hdr.width > options.max_width) {
 			scale = options.max_width / hdr.width;
 		}
 		else {


### PR DESCRIPTION
The `max_width` parameter was acting as a "set to width" parameter, meaning the canvas was being scaled to the given dimension even if the the image was smaller than `max_width`. `max_width` should only affect gifs that are larger than the given `max_width` value. 

This adds an additional test to the `get_canvas_scale` method, checking if `hdr.width` is greater than the given `max_width` option before setting `scale` to something other than 1.
