### PR TITLE
get_playing() not working

### DIFF
--- a/libgif.js
+++ b/libgif.js
@@ -887,7 +887,7 @@
             move_to: player.move_to,
 
             // getters for instance vars
-            get_playing      : function() { return player.playing },
+            get_playing      : function() { return playing },
             get_canvas       : function() { return canvas },
             get_canvas_scale : function() { return get_canvas_scale() },
             get_loading      : function() { return loading },


### PR DESCRIPTION
I executed pause() but get_playing() returned always true.
This is caused by wrong playing property.