### PR TITLE
added onError

### DIFF
--- a/libgif.js
+++ b/libgif.js
@@ -438,6 +438,7 @@
 
         var loadError = null;
         var loading = false;
+        var onErrorCallback = null;
 
         var transparency = null;
         var delay = null;
@@ -582,6 +583,8 @@
             }; // Fake header.
             frames = [];
             drawError();
+            
+            onErrorCallback && onErrorCallback(loadError, options.gif);
         };
 
         var doHdr = function (_hdr) {
@@ -934,6 +937,9 @@
             },
             load: function (callback) {
                 this.load_url(gif.getAttribute('rel:animated_src') || gif.src,callback);
+            },
+            onError: function (callback) {
+                onErrorCallback = (callback && callback.bind(this)) || null;
             },
             load_raw: function(arr, callback) {
                 if (!load_setup(callback)) return;


### PR DESCRIPTION
added onError function.

example usage: gif.onError(function (msg, img) {
        console.log('error: ', msg);
        $(this.get_canvas()).replaceWith(img);
    });