### PR TITLE
Exposed frames object.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -74,6 +74,7 @@ Of note to the developer, libjs.gif contains a class SuperGif, which can be used
 
 #### getters
 * **get_canvas** - The canvas element that the gif is playing in. Handy for assigning event handlers to.
+* **get_frames** - The list of frames objects, containing an `ImageData` instance and a `delay` amount.
 * **get_playing** - Whether or not the gif is currently playing
 * **get_loading** - Whether or not the gif has finished loading/parsing
 * **get\_auto_play** - Whether or not the gif is set to play automatically

--- a/libgif.js
+++ b/libgif.js
@@ -799,6 +799,7 @@
                 playing: playing,
                 move_relative: stepFrame,
                 current_frame: function() { return i; },
+                frames: function() { return frames },
                 length: function() { return frames.length },
                 move_to: function ( frame_idx ) {
                     i = frame_idx;
@@ -917,6 +918,7 @@
             move_to: player.move_to,
 
             // getters for instance vars
+            get_frames       : function() { return player.frames() },
             get_playing      : function() { return playing },
             get_canvas       : function() { return canvas },
             get_canvas_scale : function() { return get_canvas_scale() },


### PR DESCRIPTION
I'm using this library to parse gifs images uploaded by users.

I think that making frames list public is very useful, since you can obtain single images and timings.

If you agree, here's my PR ;)
