### PR TITLE
Pause playback when loading a new GIF to avoid errors

### DIFF
--- a/libgif.js
+++ b/libgif.js
@@ -898,6 +898,9 @@
             if (callback) load_callback = callback;
             else load_callback = false;
 
+            // Pause playback before the doStep() callback fires and frames[] is blank
+            player.pause();
+
             loading = true;
             frames = [];
             clear();


### PR DESCRIPTION
If load_url is called while the GIF is playing, the doStep() callback will attempt to read the frames[] array, which has been cleared by load_setup(). 

Simple workaround is to pause the playback before frames[] is cleared.
