### PR TITLE
Add rotation to per-frame adjustments

### DIFF
--- a/libgif.js
+++ b/libgif.js
@@ -453,7 +453,7 @@
         var ctx_scaled = false;
 
         var frames = [];
-        var frameOffsets = []; // elements have .x and .y properties
+        var frameOffsets = []; // elements have .x, .y, and .r properties
 
         var gif = options.gif;
         if (typeof options.auto_play == 'undefined')
@@ -514,6 +514,9 @@
             }
             if (typeof offset.y !== 'undefined') {
                 frameOffsets[frame].y = offset.y;
+            }
+            if (typeof offset.r !== 'undefined') {
+                frameOffsets[frame].r = offset.r;
             }
         };
 
@@ -605,7 +608,7 @@
                             data: frame.getImageData(0, 0, hdr.width, hdr.height),
                             delay: delay
                         });
-            frameOffsets.push({ x: 0, y: 0 });
+            frameOffsets.push({ x: 0, y: 0, r: 0 });
         };
 
         var doImg = function (img) {
@@ -764,7 +767,14 @@
 
                 tmpCanvas.getContext("2d").putImageData(frames[i].data, offset.x, offset.y);
                 ctx.globalCompositeOperation = "copy";
+                if (offset.r) {
+                    ctx.save();
+                    ctx.rotate(offset.r * Math.PI / 180);
+                }
                 ctx.drawImage(tmpCanvas, 0, 0);
+                if (offset.r) {
+                    ctx.restore();
+                }
             };
 
             var play = function () {


### PR DESCRIPTION
As with x/y offset, useful for aligning frames of 3-d wiggle gifs.

Use case illustrated with this code: https://github.com/ejegg/libgif-js/blob/adjust/wiggleAdjust.js

And you can play with it live here:
https://ejegg.com/stereodemo